### PR TITLE
Fix race condition and android bugs resulting in an incomplete/corrupted installation

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -34,6 +34,8 @@ import com.nordnetab.chcp.main.utils.AssetsHelper;
 import com.nordnetab.chcp.main.utils.Paths;
 import com.nordnetab.chcp.main.utils.VersionHelper;
 
+import com.nordnetab.chcp.main.model.ChcpError;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.ConfigXmlParser;
 import org.apache.cordova.CordovaArgs;
@@ -368,7 +370,12 @@ public class HotCodePushPlugin extends CordovaPlugin {
             installJsCallback = jsCallback;
         }
 
-        UpdatesInstaller.install(fileStructure);
+        if (UpdatesInstaller.install(fileStructure)) {
+          // ensure that we set the www folder as invalid, temporarily,
+          // so that if the app crashes or is killed we don't run from a corrupted www folder
+          pluginInternalPrefs.setWwwFolderInstalled(false);
+          pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+        }
     }
 
     // endregion
@@ -436,6 +443,7 @@ public class HotCodePushPlugin extends CordovaPlugin {
         currentUrl = currentUrl.replace(LOCAL_ASSETS_FOLDER, "");
         String external = Paths.get(fileStructure.wwwFolder(), currentUrl);
         if (!new File(external).exists()) {
+            Log.d("CHCP", "External starting page not found. Aborting page change.");
             return;
         }
 
@@ -617,6 +625,10 @@ public class HotCodePushPlugin extends CordovaPlugin {
     @SuppressWarnings("unused")
     public void onEvent(UpdateDownloadErrorEvent event) {
         Log.d("CHCP", "Failed to update");
+        if (event.error() == ChcpError.LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND || event.error() == ChcpError.LOCAL_VERSION_OF_MANIFEST_NOT_FOUND) {
+          Log.d("CHCP", "Can't load application config from installation folder. Reinstalling external folder");
+          installWwwFolder();
+        }
 
         PluginResult jsResult = PluginResultHelper.pluginResultFromEvent(event);
 
@@ -645,6 +657,10 @@ public class HotCodePushPlugin extends CordovaPlugin {
     public void onEvent(UpdateInstalledEvent event) {
         Log.d("CHCP", "Update is installed");
 
+        // reconfirm that our www folder is now valid
+        pluginInternalPrefs.setWwwFolderInstalled(true);
+        pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
         final PluginResult jsResult = PluginResultHelper.pluginResultFromEvent(event);
 
         if (installJsCallback != null) {
@@ -666,8 +682,12 @@ public class HotCodePushPlugin extends CordovaPlugin {
             public void run() {
                 webView.clearHistory();
                 webView.clearCache();
-                final String startingPage = getStartingPage() + "?" + System.currentTimeMillis();
-                final String externalStartingPage = FILE_PREFIX + Paths.get(fileStructure.wwwFolder(), startingPage);
+                final String external = Paths.get(fileStructure.wwwFolder(), getStartingPage());
+                if (!new File(external).exists()) {
+                    Log.d("CHCP", "External starting page not found. Aborting page change.");
+                    return;
+                }
+                final String externalStartingPage = FILE_PREFIX + external + "?" + System.currentTimeMillis();
                 webView.loadUrlIntoView(externalStartingPage, false);
             }
         });

--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
@@ -53,10 +53,10 @@ public class UpdatesInstaller {
     }
 
     private static void execute(final InstallationWorker task) {
+        isInstalling = true;
         new Thread(new Runnable() {
             @Override
             public void run() {
-                isInstalling = true;
                 task.run();
                 isInstalling = false;
             }


### PR DESCRIPTION
This will make sure the www folder is never left in a corrupted state. If it is corrupted, it will always be recreated on app start. See: https://github.com/nordnet/cordova-hot-code-push/issues/43

Also once I added logging, I noticed a race condition with two installations being started concurrently, and interfering with each other's files. 

I noticed that **two** calls were being made to the `install` method, and because isInstalling was set from within the thread, both installs would start concurrently. See the small fix in UpdatesInstaller.java.

The two threads would then compete over the `www_backup` folder, and in my app's case, this would always fail the update because I have a lot of files in the app and file system errors would occur as the two threads were deleting and creating the same files. I believe this was probably the root cause of issue #43, but the strengthening added for that doesn't hurt either.
