### PR TITLE
Remove empty chcp tag in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,9 +26,6 @@
     <!-- Config.xml preferences -->
     <config-file target="config.xml" parent="/*">
       <preference name="loadUrlTimeoutValue" value="60000" />
-      <chcp>
-        <!-- <config-file url="url to your chcp.json file"/> -->
-      </chcp>
     </config-file>
 
     <!-- Hooks -->


### PR DESCRIPTION
This prevents a timing issue where the initial prepare created an empty
chcp tag in config.xml that causes the plugin to stop functioning.
Fixes #70
