### PR TITLE
chcp_beforeInstall event

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Available events are:
 - `chcp_updateIsReadyToInstall` - send when new release was successfully loaded and ready to be installed.
 - `chcp_updateLoadFailed` - send when plugin couldn't load update from the server. Error details are attached to the event.
 - `chcp_nothingToUpdate` - send when we successfully loaded application config from the server, but there is nothing new is available.
+- `chcp_beforeInstall` - sent when an update is about to be installed.
 - `chcp_updateInstalled` - send when update was successfully installed.
 - `chcp_updateInstallFailed` - send when update installation failed. Error details are attached to the event.
 - `chcp_nothingToInstall` - send when there is nothing to install. Probably, nothing was loaded before that.

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -10,6 +10,7 @@ import com.nordnetab.chcp.main.config.ContentConfig;
 import com.nordnetab.chcp.main.config.PluginInternalPreferences;
 import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
 import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
+import com.nordnetab.chcp.main.events.BeforeInstallEvent;
 import com.nordnetab.chcp.main.events.NothingToInstallEvent;
 import com.nordnetab.chcp.main.events.NothingToUpdateEvent;
 import com.nordnetab.chcp.main.events.UpdateDownloadErrorEvent;
@@ -625,6 +626,24 @@ public class HotCodePushPlugin extends CordovaPlugin {
             downloadJsCallback.sendPluginResult(jsResult);
             downloadJsCallback = null;
         }
+
+        sendMessageToDefaultCallback(jsResult);
+    }
+
+    /**
+     * Listener for event that an update is about to begin
+     *
+     * @param event event information
+     * @see EventBus
+     * @see BeforeInstallEvent
+     * @see UpdatesLoader
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(BeforeInstallEvent event) {
+        Log.d("CHCP", "Before install");
+
+        PluginResult jsResult = PluginResultHelper.pluginResultFromEvent(event);
 
         sendMessageToDefaultCallback(jsResult);
     }

--- a/src/android/src/com/nordnetab/chcp/main/events/BeforeInstallEvent.java
+++ b/src/android/src/com/nordnetab/chcp/main/events/BeforeInstallEvent.java
@@ -1,0 +1,18 @@
+package com.nordnetab.chcp.main.events;
+
+/**
+ * Contributed by Torsten Freyhall on 09.02.16.
+ * <p/>
+ * Event is sent when an update is about to be installed.
+ */
+public class BeforeInstallEvent extends WorkerEvent {
+
+    public static final String EVENT_NAME = "chcp_beforeInstall";
+
+    /**
+     * Class constructor.
+     */
+    public BeforeInstallEvent() {
+        super(EVENT_NAME, null, null);
+    }
+}

--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
@@ -3,6 +3,7 @@ package com.nordnetab.chcp.main.updater;
 import android.content.Context;
 import android.util.Log;
 
+import com.nordnetab.chcp.main.events.BeforeInstallEvent;
 import com.nordnetab.chcp.main.events.NothingToInstallEvent;
 import com.nordnetab.chcp.main.model.ChcpError;
 import com.nordnetab.chcp.main.model.PluginFilesStructure;
@@ -57,6 +58,8 @@ public class UpdatesInstaller {
             return ChcpError.NOTHING_TO_INSTALL;
         }
 
+        dispatchBeforeInstallEvent();
+
         final WorkerTask task = new InstallationWorker(context, newVersion, currentVersion);
         execute(task);
 
@@ -75,5 +78,9 @@ public class UpdatesInstaller {
                 EventBus.getDefault().post(task.result());
             }
         }).start();
+    }
+
+    private static void dispatchBeforeInstallEvent() {
+        EventBus.getDefault().post(new BeforeInstallEvent());
     }
 }

--- a/src/ios/Events/HCPEvents.h
+++ b/src/ios/Events/HCPEvents.h
@@ -24,6 +24,11 @@ extern NSString *const kHCPNothingToUpdateEvent;
 extern NSString *const kHCPUpdateIsReadyForInstallationEvent;
 
 /**
+ *  Event is dispatched when installation is about to begin
+ */
+extern NSString *const kHCPBeforeInstallEvent;
+
+/**
  *  Event is dispatched we failed to install the update.
  */
 extern NSString *const kHCPUpdateInstallationErrorEvent;

--- a/src/ios/Events/HCPEvents.m
+++ b/src/ios/Events/HCPEvents.m
@@ -11,6 +11,7 @@
 NSString *const kHCPUpdateDownloadErrorEvent = @"chcp_updateLoadFailed";
 NSString *const kHCPNothingToUpdateEvent = @"chcp_nothingToUpdate";
 NSString *const kHCPUpdateIsReadyForInstallationEvent = @"chcp_updateIsReadyToInstall";
+NSString *const kHCPBeforeInstallEvent = @"chcp_beforeInstall";
 NSString *const kHCPUpdateInstallationErrorEvent = @"chcp_updateInstallFailed";
 NSString *const kHCPUpdateIsInstalledEvent = @"chcp_updateInstalled";
 NSString *const kHCPNothingToInstallEvent = @"chcp_nothingToInstall";

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -384,6 +384,10 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                                name:kHCPUpdateInstallationErrorEvent
                              object:nil];
     [notificationCenter addObserver:self
+                           selector:@selector(onBeforeInstallEvent:)
+                               name:kHCPBeforeInstallEvent
+                             object:nil];
+    [notificationCenter addObserver:self
                            selector:@selector(onUpdateInstalledEvent:)
                                name:kHCPUpdateIsInstalledEvent
                              object:nil];
@@ -536,6 +540,18 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_installationCallback];
         _installationCallback = nil;
     }
+    
+    // send notification to the default callback
+    [self invokeDefaultCallbackWithMessage:pluginResult];
+}
+
+/**
+ *  Method is called when installation is about to begin
+ *
+ *  @param notification captured notification with the event details
+ */
+- (void)onBeforeInstallEvent:(NSNotification *)notification {
+    CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
     
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];

--- a/src/ios/Updater/HCPInstallationWorker.m
+++ b/src/ios/Updater/HCPInstallationWorker.m
@@ -47,6 +47,8 @@
 }
 
 - (void)runWithComplitionBlock:(void (^)(void))updateInstallationComplitionBlock {
+    [self dispatchBeforeInstallEvent];
+
     NSError *error = nil;
     if (![self initBeforeRun:&error] ||
         ![self isUpdateValid:&error] ||
@@ -66,6 +68,17 @@
 }
 
 #pragma mark Private API
+
+/**
+ *  Send event that update is about to begin
+ */
+- (void)dispatchBeforeInstallEvent {
+    NSNotification *notification = [HCPEvents notificationWithName:kHCPBeforeInstallEvent
+                                                 applicationConfig:_newConfig
+                                                            taskId:self.workerId];
+    
+    [[NSNotificationCenter defaultCenter] postNotification:notification];
+}
 
 /**
  *  Send update installation failure event with error details.

--- a/www/chcp.js
+++ b/www/chcp.js
@@ -23,6 +23,7 @@ var exec = require('cordova/exec'),
     'chcp_updateLoadFailed': true,
     'chcp_nothingToUpdate': true,
     'chcp_updateIsReadyToInstall': true,
+    'chcp_beforeInstall': true,
     'chcp_updateInstallFailed': true,
     'chcp_updateInstalled': true,
     'chcp_nothingToInstall': true
@@ -153,7 +154,7 @@ var chcp = {
   error: {
     NOTHING_TO_INSTALL: 1,
     NOTHING_TO_UPDATE: 2,
-    
+
     FAILED_TO_DOWNLOAD_APPLICATION_CONFIG: -1,
     APPLICATION_BUILD_VERSION_TOO_LOW: -2,
     FAILED_TO_DOWNLOAD_CONTENT_MANIFEST: -3,


### PR DESCRIPTION
I've implemented and tested this for iOS. Event is triggered correctly, and I can use it for showing the splash screen as desired in #100.

For Android, maybe the easiest way to fix this is to trigger the event before the InstallationWorker runs?
