### PR TITLE
Allow headers for server communication

### DIFF
--- a/src/ios/HCPPlugin.h
+++ b/src/ios/HCPPlugin.h
@@ -50,4 +50,6 @@
  */
 - (void)jsRequestAppUpdate:(CDVInvokedUrlCommand *)command;
 
+@property (nonatomic, retain) NSDictionary* headers;
+
 @end

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -149,7 +149,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         return NO;
     }
     
-    NSString *taskId = [_updatesLoader addUpdateTaskToQueueWithConfigUrl:_pluginXmllConfig.configUrl];
+    NSString *taskId = [_updatesLoader addUpdateTaskToQueueWithConfigUrl:_pluginXmllConfig.configUrl headers: self.headers];
     [self storeCallback:callbackId forFetchTask:taskId];
     
     return taskId != nil;
@@ -625,6 +625,11 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 - (void)jsFetchUpdate:(CDVInvokedUrlCommand *)command {
     if (!_isPluginReadyForWork) {
         return;
+    }
+
+    // headers may be passed as first argument, as a dict
+    if (command.arguments.count == 1) {
+        self.headers = command.arguments[0];
     }
     
     [self _fetchUpdate:command.callbackId];

--- a/src/ios/Network/HCPFileDownloader.h
+++ b/src/ios/Network/HCPFileDownloader.h
@@ -46,4 +46,7 @@ typedef void (^HCPDataDownloadCompletionBlock)(NSData *data, NSError *error);
  */
 - (void) downloadFiles:(NSArray *)filesList fromURL:(NSURL *)contentURL toFolder:(NSURL *)folderURL completionBlock:(HCPFileDownloadCompletionBlock)block;
 
+// headers to add to the session
+@property (nonatomic, retain) NSDictionary* headers;
+
 @end

--- a/src/ios/Network/HCPFileDownloader.m
+++ b/src/ios/Network/HCPFileDownloader.m
@@ -16,6 +16,9 @@
 - (void) downloadDataFromUrl:(NSURL*) url completionBlock:(HCPDataDownloadCompletionBlock) block {
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    if (self.headers) {
+        [configuration setHTTPAdditionalHeaders:self.headers];
+    }
     NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
     
     NSURLSessionDataTask* dowloadTask = [session dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
@@ -28,6 +31,9 @@
 - (void) downloadFiles:(NSArray *)filesList fromURL:(NSURL *)contentURL toFolder:(NSURL *)folderURL completionBlock:(HCPFileDownloadCompletionBlock)block {
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    if (self.headers) {
+        [configuration setHTTPAdditionalHeaders:self.headers];
+    }
     NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
     
     __block NSMutableSet* startedTasks = [NSMutableSet set];

--- a/src/ios/Updater/HCPUpdateLoader.h
+++ b/src/ios/Updater/HCPUpdateLoader.h
@@ -31,10 +31,11 @@
  *  Add update download task to queue. It will be executed as fast as possible.
  *
  *  @param configUrl url to the application config on the server
+ *  @param optional authorization header
  *
  *  @return id of the created worker
  */
-- (NSString *)addUpdateTaskToQueueWithConfigUrl:(NSURL *)configUrl;
+- (NSString *)addUpdateTaskToQueueWithConfigUrl:(NSURL *)configUrl headers: (NSDictionary*) headers;
 
 /**
  *  Setup loader. Should be called on application startup before any real work is performed.

--- a/src/ios/Updater/HCPUpdateLoader.m
+++ b/src/ios/Updater/HCPUpdateLoader.m
@@ -37,14 +37,15 @@
     _filesStructure = filesStructure;
 }
 
-- (NSString *)addUpdateTaskToQueueWithConfigUrl:(NSURL *)configUrl {
+- (NSString *)addUpdateTaskToQueueWithConfigUrl:(NSURL *)configUrl headers: (NSDictionary*) headers {
     // TODO: add better communication between installer and loader.
     // For now - skip update load request if installation or download is in progress.
     if ([HCPUpdateInstaller sharedInstance].isInstallationInProgress || _isExecuting) {
         return nil;
     }
-    
-    id<HCPWorker> task = [[HCPUpdateLoaderWorker alloc] initWithConfigUrl:configUrl filesStructure:_filesStructure];
+    HCPUpdateLoaderWorker* task = [[HCPUpdateLoaderWorker alloc] initWithConfigUrl:configUrl filesStructure:_filesStructure];
+        
+    task.headers = headers;
     [self executeTask:task];
     
     return task.workerId;

--- a/src/ios/Updater/HCPUpdateLoaderWorker.h
+++ b/src/ios/Updater/HCPUpdateLoaderWorker.h
@@ -26,4 +26,5 @@
  */
 - (instancetype)initWithConfigUrl:(NSURL *)configURL filesStructure:(id<HCPFilesStructure>)fileStructure;
 
+@property (nonatomic, retain) NSDictionary* headers;
 @end

--- a/src/ios/Updater/HCPUpdateLoaderWorker.m
+++ b/src/ios/Updater/HCPUpdateLoaderWorker.m
@@ -62,6 +62,7 @@
     }
     
     HCPFileDownloader *configDownloader = [[HCPFileDownloader alloc] init];
+    configDownloader.headers = self.headers;
     
     // download new application config
     [configDownloader downloadDataFromUrl:_configURL completionBlock:^(NSData *data, NSError *error) {
@@ -125,7 +126,9 @@
     
     // download files
     HCPFileDownloader *downloader = [[HCPFileDownloader alloc] init];
-    // TODO: set credentials on downloader
+    
+    // pass headers (auth or other)
+    downloader.headers = self.headers;
     
     [downloader downloadFiles:updatedFiles
                       fromURL:newAppConfig.contentConfig.contentURL

--- a/www/chcp.js
+++ b/www/chcp.js
@@ -204,16 +204,22 @@ var chcp = {
    * Usually this is done automatically by the plugin, but can be triggered at any time from the web page.
    *
    * @param {Callback(error, data)} callback - called when native side finished update process
+   * @param headers - provide optional headers object. This will be used to configure server request
    */
-  fetchUpdate: function(callback) {
+  fetchUpdate: function(callback, headers) {
     var innerCallback = function(msg) {
       var resultObj = processMessageFromNative(msg);
       if (callback !== undefined && callback != null) {
         callback(resultObj.error, resultObj.data);
       }
     };
+    
+    var _headers = []
+    if (headers !== undefined && headers != null) {
+        _headers = [headers];
+    }
 
-    exec(innerCallback, null, PLUGIN_NAME, pluginNativeMethod.FETCH_UPDATE, []);
+    exec(innerCallback, null, PLUGIN_NAME, pluginNativeMethod.FETCH_UPDATE, _headers);
   },
 
   /**


### PR DESCRIPTION
This is the rebased version to allow headers to be set in all communications to server. The older PR can be discarded (unless the documentation part would be wanted to update the wiki).

Use it to set Basic Auth Authorization for example.

@nikDemyankov Thanks for all your work here, this plugin saves me a million hours :-)
