### PR TITLE
Speed up android initial assets copy

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -567,7 +567,8 @@ public class HotCodePushPlugin extends CordovaPlugin {
             pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
         }
 
-        AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getAssets(), WWW_FOLDER, fileStructure.getWwwFolder());
+
+        AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContext(),cordova.getActivity().getAssets(), WWW_FOLDER, fileStructure.getWwwFolder());
     }
 
     /**

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -568,7 +568,7 @@ public class HotCodePushPlugin extends CordovaPlugin {
         }
 
 
-        AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContext(),cordova.getActivity().getAssets(), WWW_FOLDER, fileStructure.getWwwFolder());
+        AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContext(), WWW_FOLDER, fileStructure.getWwwFolder());
     }
 
     /**

--- a/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
+++ b/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
@@ -1,17 +1,23 @@
 package com.nordnetab.chcp.main.utils;
 
+import android.content.Context;
 import android.content.res.AssetManager;
 
 import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
 import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
 import com.nordnetab.chcp.main.events.BeforeAssetsInstalledEvent;
 
+import org.apache.cordova.LOG;
 import org.greenrobot.eventbus.EventBus;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * Created by Nikolay Demyankov on 21.07.15.
@@ -29,15 +35,15 @@ public class AssetsHelper {
      * Copy files from the assets folder into the specific folder on the external storage.
      * Method runs asynchronously. Results are dispatched through events.
      *
-     * @param assetManager  assets manager
-     * @param fromDirectory which directory in assets we want to copy
-     * @param toDirectory   absolute path to the destination folder on the external storage
-     *
+     * @param applicationContext
+     * @param assetManager       assets manager
+     * @param fromDirectory      which directory in assets we want to copy
+     * @param toDirectory        absolute path to the destination folder on the external storage
      * @see AssetsInstallationErrorEvent
      * @see AssetsInstalledEvent
      * @see EventBus
      */
-    public static void copyAssetDirectoryToAppDirectory(final AssetManager assetManager, final String fromDirectory, final String toDirectory) {
+    public static void copyAssetDirectoryToAppDirectory(final Context applicationContext, final AssetManager assetManager, final String fromDirectory, final String toDirectory) {
         if (isWorking) {
             return;
         }
@@ -50,8 +56,11 @@ public class AssetsHelper {
             @Override
             public void run() {
                 try {
-                    copyAssetDirectory(assetManager, fromDirectory, toDirectory);
+                    long start = System.currentTimeMillis();
+                    copyAssetDirectory(applicationContext, fromDirectory, toDirectory);
                     EventBus.getDefault().post(new AssetsInstalledEvent());
+                    long time = System.currentTimeMillis() - start;
+                    LOG.d("CHCP", "Copied assets in : %d ms", time);
                 } catch (IOException e) {
                     e.printStackTrace();
                     EventBus.getDefault().post(new AssetsInstallationErrorEvent());
@@ -62,33 +71,33 @@ public class AssetsHelper {
         }).start();
     }
 
-    private static void copyAssetDirectory(AssetManager assetManager, String fromDirectory, String toDirectory) throws IOException {
+    private static void copyAssetDirectory(Context applicationContext, String fromDirectory, String toDirectory) throws IOException {
         // recreate cache folder
         FilesUtility.delete(toDirectory);
         FilesUtility.ensureDirectoryExists(toDirectory);
+        JarFile jarFile = new JarFile(applicationContext.getApplicationInfo().sourceDir);
 
-        // copy files
-        String[] files = assetManager.list(fromDirectory);
-        for (String file : files) {
-            final String destinationFileAbsolutePath = com.nordnetab.chcp.main.utils.Paths.get(toDirectory, file);
-            final String assetFileAbsolutePath = Paths.get(fromDirectory, file).substring(1);
+        String prefix = "assets/" + fromDirectory;
+        int prefixLength = prefix.length();
+        Enumeration<JarEntry> enu = jarFile.entries();
+        while (enu.hasMoreElements()) {
+            JarEntry fileJarEntry = enu.nextElement();
+            String name = fileJarEntry.getName();
+            if (!fileJarEntry.isDirectory() && name.startsWith(prefix)) {
+                final String destinationFileAbsolutePath = Paths.get(toDirectory, name.substring(prefixLength));
 
-            String subFiles[] = assetManager.list(assetFileAbsolutePath);
-            if (subFiles.length == 0) {
-                copyAssetFile(assetManager, assetFileAbsolutePath, destinationFileAbsolutePath);
-            } else {
-                copyAssetDirectory(assetManager, assetFileAbsolutePath, destinationFileAbsolutePath);
+                copyAssetFile(jarFile.getInputStream(fileJarEntry), destinationFileAbsolutePath);
             }
         }
+
     }
 
     /**
      * Copies asset file to destination path
      */
-    private static void copyAssetFile(AssetManager assetManager, String assetFilePath, String destinationFilePath) throws IOException {
-        InputStream in = assetManager.open(assetFilePath);
+    private static void copyAssetFile(InputStream in, String destinationFilePath) throws IOException {
+        FilesUtility.ensureDirectoryExists(new File(destinationFilePath).getParent());
         OutputStream out = new FileOutputStream(destinationFilePath);
-
         // Transfer bytes from in to out
         byte[] buf = new byte[8192];
         int len;
@@ -99,4 +108,5 @@ public class AssetsHelper {
         in.close();
         out.close();
     }
+
 }

--- a/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
+++ b/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
@@ -1,7 +1,6 @@
 package com.nordnetab.chcp.main.utils;
 
 import android.content.Context;
-import android.content.res.AssetManager;
 
 import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
 import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
@@ -35,15 +34,14 @@ public class AssetsHelper {
      * Copy files from the assets folder into the specific folder on the external storage.
      * Method runs asynchronously. Results are dispatched through events.
      *
-     * @param applicationContext
-     * @param assetManager       assets manager
+     * @param applicationContext current application context
      * @param fromDirectory      which directory in assets we want to copy
      * @param toDirectory        absolute path to the destination folder on the external storage
      * @see AssetsInstallationErrorEvent
      * @see AssetsInstalledEvent
      * @see EventBus
      */
-    public static void copyAssetDirectoryToAppDirectory(final Context applicationContext, final AssetManager assetManager, final String fromDirectory, final String toDirectory) {
+    public static void copyAssetDirectoryToAppDirectory(final Context applicationContext, final String fromDirectory, final String toDirectory) {
         if (isWorking) {
             return;
         }


### PR DESCRIPTION
Androids AssetManager.list method is known to have performance issues, leading to ASSETS_FOLDER_IN_NOT_YET_INSTALLED error in this case.

Initial assets copy uses now java.util.jar.JarFile to enumerate and extract
assets, wich is much faster.
