### PR TITLE
	Bugfix: Android app crashed on absent contentUrl in a new content config

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdateLoaderWorker.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdateLoaderWorker.java
@@ -24,7 +24,6 @@ import com.nordnetab.chcp.main.storage.IObjectFileStorage;
 import com.nordnetab.chcp.main.utils.FilesUtility;
 import com.nordnetab.chcp.main.utils.URLUtility;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +77,9 @@ class UpdateLoaderWorker implements WorkerTask {
             return;
         }
         final ContentConfig newContentConfig = newAppConfig.getContentConfig();
-        if (newContentConfig == null || TextUtils.isEmpty(newContentConfig.getReleaseVersion())) {
+        if (newContentConfig == null
+                || TextUtils.isEmpty(newContentConfig.getReleaseVersion())
+                || TextUtils.isEmpty(newContentConfig.getContentUrl())) {
             setErrorResult(ChcpError.NEW_APPLICATION_CONFIG_IS_INVALID, null);
             return;
         }


### PR DESCRIPTION
A small bugfix for android.  
