### PR TITLE
Avoiding -7 Error after application update

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/updater/InstallationWorker.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/InstallationWorker.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import com.nordnetab.chcp.main.config.ApplicationConfig;
 import com.nordnetab.chcp.main.config.ContentManifest;
-import com.nordnetab.chcp.main.events.NothingToInstallEvent;
 import com.nordnetab.chcp.main.events.UpdateInstallationErrorEvent;
 import com.nordnetab.chcp.main.events.UpdateInstalledEvent;
 import com.nordnetab.chcp.main.events.WorkerEvent;
@@ -74,7 +73,7 @@ class InstallationWorker implements WorkerTask {
         deleteUnusedFiles();
 
         // install the update
-        boolean isInstalled = moveFilesFromInstallationFolderToWwwFodler();
+        boolean isInstalled = moveFilesFromInstallationFolderToWwwFolder();
         if (!isInstalled) {
             cleanUpOnFailure();
             setResultForError(ChcpError.FAILED_TO_COPY_NEW_CONTENT_FILES);
@@ -130,8 +129,11 @@ class InstallationWorker implements WorkerTask {
      */
     private boolean copyFilesFromCurrentReleaseToNewRelease() {
         boolean result = true;
+        // Happens in some weird cases
+        if(currentReleaseFS.getWwwFolder().equals(newReleaseFS.getWwwFolder())) return result;
         final File currentWwwFolder = new File(currentReleaseFS.getWwwFolder());
         final File newWwwFolder = new File(newReleaseFS.getWwwFolder());
+
         try {
             // just in case if www folder already exists - remove it
             if (newWwwFolder.exists()) {
@@ -177,7 +179,7 @@ class InstallationWorker implements WorkerTask {
      *
      * @return <code>true</code> if files are copied; <code>false</code> - otherwise
      */
-    private boolean moveFilesFromInstallationFolderToWwwFodler() {
+    private boolean moveFilesFromInstallationFolderToWwwFolder() {
         try {
             FilesUtility.copy(newReleaseFS.getDownloadFolder(), newReleaseFS.getWwwFolder());
 

--- a/src/ios/Updater/HCPInstallationWorker.m
+++ b/src/ios/Updater/HCPInstallationWorker.m
@@ -194,7 +194,7 @@
 
 - (BOOL)copyFilesFromCurrentReleaseToNewRelease:(NSError **)error {
     *error = nil;
-    
+    if ([_newReleaseFS.wwwFolder.path isEqualToString: _currentReleaseFS.wwwFolder.path]) return YES;
     // just in case check if previous www folder exists; if it does - remove it before copying new stuff
     if ([_fileManager fileExistsAtPath:_newReleaseFS.wwwFolder.path]) {
         [_fileManager removeItemAtURL:_newReleaseFS.wwwFolder error:nil];


### PR DESCRIPTION
After an application update, the first update attempt failed with -7  error if the new release version on server was already installed prior to application update. This pull request handles the situation, skipping unnecessary copy, although it feels like a workaround for a bug.  

Could it be a better idea to reset the current release version in pluginInternalPrefs to the release version from the application (assets version) on assets install? Otherwise assets files files from the plugins directory or other files not listed in the chcp.manifest could get lost, because the update is run on top of the last release from the pluginInternalPrefs.

The drawback is a possibility of loading same files anew, but it feels safer.
