### PR TITLE
fix when app verlay installation，www content update filed

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/updater/InstallationWorker.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/InstallationWorker.java
@@ -129,6 +129,12 @@ class InstallationWorker implements WorkerTask {
      * @return <code>true</code> if files are copied; <code>false</code> - otherwise.
      */
     private boolean copyFilesFromCurrentReleaseToNewRelease() {
+        //fix when app verlay installation，www content update filed
+        //error is code: -7, description: "Can't copy files from previous release to the new release"
+        if(currentReleaseFS != null && currentReleaseFS.getWwwFolder() != null
+                && currentReleaseFS.getWwwFolder().equals(newReleaseFS.getWwwFolder())) {
+            return true;
+        }
         boolean result = true;
         final File currentWwwFolder = new File(currentReleaseFS.getWwwFolder());
         final File newWwwFolder = new File(newReleaseFS.getWwwFolder());

--- a/src/ios/Updater/HCPInstallationWorker.m
+++ b/src/ios/Updater/HCPInstallationWorker.m
@@ -193,6 +193,13 @@
 }
 
 - (BOOL)copyFilesFromCurrentReleaseToNewRelease:(NSError **)error {
+    //fix when app verlay installation，www content update filed
+    //error is code: -7, description: "Can't copy files from previous release to the new release"
+    if(_currentReleaseFS != nil && _currentReleaseFS.wwwFolder != nil
+       && [_currentReleaseFS.wwwFolder.path isEqualToString:_newReleaseFS.wwwFolder.path]) {
+        return YES;
+    }
+    
     *error = nil;
     
     // just in case check if previous www folder exists; if it does - remove it before copying new stuff


### PR DESCRIPTION
currentRelease is equals newRelease so get error is code: -7, description: "Can't copy files from previous release to the new release"
