### PR TITLE
Fix error LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND on application update (via the store)

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -592,6 +592,8 @@ public class HotCodePushPlugin extends CordovaPlugin {
             pluginInternalPrefs.setCurrentReleaseVersionName(appConfig.getContentConfig().getReleaseVersion());
 
             pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
+            fileStructure.switchToRelease(pluginInternalPrefs.getCurrentReleaseVersionName());
         }
 
         AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContext(), WWW_FOLDER, fileStructure.getWwwFolder());

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -106,6 +106,8 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         _pluginInternalPrefs.currentReleaseVersionName = config.contentConfig.releaseVersion;
         
         [_pluginInternalPrefs saveToUserDefaults];
+
+        _filesStructure = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.currentReleaseVersionName];
     }
     
     [HCPAssetsFolderHelper installWwwFolderToExternalStorageFolder:_filesStructure.wwwFolder];


### PR DESCRIPTION
In function `installWwwFolder`, the `www` folder is copied from the asset file by:
```java
AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContex
t(), WWW_FOLDER, fileStructure.getWwwFolder());
```
So, we have to make sure that `fileStructure` is updated to return the correct folder, corresponding to the current release version, before that. Otherwise, `chcp.json` will not be found in the expected folder later on and we get an error `LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND`.