### PR TITLE
Feature/local override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nordnet/cordova-hot-code-push.git"
+    "url": "https://github.com/mobilexag/cordova-hot-code-push.git"
   },
   "keywords": [
     "cordova",
@@ -24,16 +24,15 @@
     "cordova-android",
     "cordova-ios"
   ],
-  "engines": [
-    {
-      "name": "cordova-android",
-      "version": ">=4"
-    },
-    {
-      "name": "cordova-plugman",
-      "version": ">=4.2.0"
+  "engines": {
+    "cordovaDependencies": {
+      "1.5.3": {
+        "cordova-ios": ">3.8",
+        "cordova-android": ">=4",
+        "cordova-plugman": ">=4.2.0"
+      }
     }
-  ],
+  },
   "dependencies": {
     "xml2js": "^0.4"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mobilexag/cordova-hot-code-push.git"
+    "url": "https://github.com/nordnet/cordova-hot-code-push.git"
   },
   "keywords": [
     "cordova",

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -551,11 +551,12 @@ public class HotCodePushPlugin extends CordovaPlugin {
      * @return <code>true</code> - plugin is ready; otherwise - <code>false</code>
      */
     private boolean isPluginReadyForWork() {
+        boolean isForceInstallIsAllowed = chcpXmlConfig.isForceInstallIsAllowed();
         boolean isWwwFolderExists = isWwwFolderExists();
         boolean isWwwFolderInstalled = pluginInternalPrefs.isWwwFolderInstalled();
         boolean isApplicationHasBeenUpdated = isApplicationHasBeenUpdated();
 
-        return isWwwFolderExists && isWwwFolderInstalled && !isApplicationHasBeenUpdated;
+        return isWwwFolderExists && isWwwFolderInstalled && !isApplicationHasBeenUpdated && !isForceInstallIsAllowed;
     }
 
     /**

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -117,7 +117,8 @@ public class HotCodePushPlugin extends CordovaPlugin {
         // ensure that www folder installed on external storage;
         // if not - install it
         isPluginReadyForWork = isPluginReadyForWork();
-        if (!isPluginReadyForWork) {
+        boolean isForceInstallIsAllowed = chcpXmlConfig.isForceInstallIsAllowed();
+        if (!isPluginReadyForWork || isForceInstallIsAllowed) {
             dontReloadOnStart = true;
             installWwwFolder();
             return;
@@ -551,12 +552,11 @@ public class HotCodePushPlugin extends CordovaPlugin {
      * @return <code>true</code> - plugin is ready; otherwise - <code>false</code>
      */
     private boolean isPluginReadyForWork() {
-        boolean isForceInstallIsAllowed = chcpXmlConfig.isForceInstallIsAllowed();
         boolean isWwwFolderExists = isWwwFolderExists();
         boolean isWwwFolderInstalled = pluginInternalPrefs.isWwwFolderInstalled();
         boolean isApplicationHasBeenUpdated = isApplicationHasBeenUpdated();
 
-        return isWwwFolderExists && isWwwFolderInstalled && !isApplicationHasBeenUpdated && !isForceInstallIsAllowed;
+        return isWwwFolderExists && isWwwFolderInstalled && !isApplicationHasBeenUpdated;
     }
 
     /**

--- a/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfig.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfig.java
@@ -16,12 +16,14 @@ public class ChcpXmlConfig {
     private String configUrl;
     private boolean allowUpdatesAutoDownload;
     private boolean allowUpdatesAutoInstall;
+    private boolean allowForceInstall;
     private int nativeInterfaceVersion;
 
     private ChcpXmlConfig() {
         configUrl = "";
         allowUpdatesAutoDownload = true;
         allowUpdatesAutoInstall = true;
+        allowForceInstall = false;
         nativeInterfaceVersion = 1;
     }
 
@@ -98,6 +100,25 @@ public class ChcpXmlConfig {
      * */
     void setNativeInterfaceVersion(int version) {
         nativeInterfaceVersion = version > 0 ? version : 1;
+    }
+
+    /**
+     * Setter for the flag if force install is allowed.
+     *
+     * @param isAllowed set to <code>true</code> to allow the local www version to be preferred over the already copied version
+     */
+    public void allowForceInstall(boolean isAllowed) {
+        allowForceInstall = isAllowed;
+    }
+
+    /**
+     * Getter for the flag if force install is allowed.
+     * By default it is off, but you can turn it on in the config.xml.
+     *
+     * @return <code>true</code> if local override is enabled, <code>false</code> - otherwise.
+     */
+    public boolean isForceInstallIsAllowed() {
+        return allowForceInstall;
     }
 
     /**

--- a/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfigParser.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfigParser.java
@@ -72,6 +72,12 @@ class ChcpXmlConfigParser extends ConfigXmlParser {
             return;
         }
 
+        // parse force install preference
+        if (XmlTags.FORCE_INSTALL_TAG.equals(name)) {
+            processForceInstallBlock(xml);
+            return;
+        }
+
         // parse native navigation interface version
         if (XmlTags.NATIVE_INTERFACE_TAG.equals(name)) {
             processNativeInterfaceBlock(xml);
@@ -112,5 +118,10 @@ class ChcpXmlConfigParser extends ConfigXmlParser {
         final int nativeVersion = Integer.parseInt(nativeVersionStr);
 
         chcpConfig.setNativeInterfaceVersion(nativeVersion);
+    }
+
+    private void processForceInstallBlock(final XmlPullParser xml) {
+        boolean isEnabled = xml.getAttributeValue(null, XmlTags.FORCE_INSTALL_ENABLED_ATTRIBUTE).equals("true");
+        chcpConfig.allowForceInstall(isEnabled);
     }
 }

--- a/src/android/src/com/nordnetab/chcp/main/config/XmlTags.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/XmlTags.java
@@ -28,4 +28,7 @@ final class XmlTags {
     public static final String NATIVE_INTERFACE_TAG = "native-interface";
     public static final String NATIVE_INTERFACE_VERSION_ATTRIBUTE = "version";
 
+    // keys for force install
+    public static final String FORCE_INSTALL_TAG = "force-install";
+    public static final String FORCE_INSTALL_ENABLED_ATTRIBUTE = "enabled";
 }

--- a/src/ios/Config/HCPXmlConfig.h
+++ b/src/ios/Config/HCPXmlConfig.h
@@ -32,6 +32,13 @@
 @property (nonatomic, getter=isUpdatesAutoInstallationAllowed) BOOL allowUpdatesAutoInstallation;
 
 /**
+ *  Flag that indicates if updates auto installation is allowed. By default - <code>YES</code>.
+ *
+ *  @return <code>YES</code> if auto installation is allowed; <code>NO</code> if auto installation is disabled
+ */
+@property (nonatomic, getter=isForceInstallAllowed) BOOL allowForceInstall;
+
+/**
  *  Current native interface version of the application.
  */
 @property (nonatomic) NSUInteger nativeInterfaceVersion;

--- a/src/ios/Config/HCPXmlConfig.m
+++ b/src/ios/Config/HCPXmlConfig.m
@@ -17,6 +17,7 @@
         _allowUpdatesAutoInstallation = YES;
         _configUrl = nil;
         _nativeInterfaceVersion = 1;
+        _allowForceInstall = NO;
     }
     
     return self;

--- a/src/ios/Config/HCPXmlConfigParser.m
+++ b/src/ios/Config/HCPXmlConfigParser.m
@@ -66,7 +66,9 @@
         [self parseAutoInstallOptions:attributeDict];
     } else if ([elementName isEqualToString:kHCPNativeInterfaceXmlTag]) {
         [self parseNativeInterfaceOptions:attributeDict];
-    }
+    } else if ([elementName isEqualToString:kHCPForceInstallXmlTag]) {
+        [self parseForceInstallOptions:attributeDict];
+    } 
 }
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName {
@@ -96,6 +98,10 @@
 
 - (void)parseNativeInterfaceOptions:(NSDictionary *)attributeDict {
     _xmlConfig.nativeInterfaceVersion = [(NSString *)attributeDict[kHCPNativeInterfaceVersionXmlAttribute] integerValue];
+}
+
+- (void)parseForceInstallOptions:(NSDictionary *)attributeDict {
+    _xmlConfig.allowForceInstall = [(NSNumber *)attributeDict[kHCPForceInstallEnabledXmlAttribute] boolValue];
 }
 
 @end

--- a/src/ios/Config/HCPXmlTags.h
+++ b/src/ios/Config/HCPXmlTags.h
@@ -23,6 +23,10 @@ extern NSString *const kHCPAutoInstallEnabledXmlAttribute;
 extern NSString *const kHCPNativeInterfaceXmlTag;
 extern NSString *const kHCPNativeInterfaceVersionXmlAttribute;
 
+// Keys for processing force install options
+extern NSString *const kHCPForceInstallXmlTag;
+extern NSString *const kHCPForceInstallEnabledXmlAttribute;
+
 @interface HCPXmlTags : NSObject
 
 @end

--- a/src/ios/Config/HCPXmlTags.m
+++ b/src/ios/Config/HCPXmlTags.m
@@ -24,6 +24,10 @@ NSString *const kHCPAutoInstallEnabledXmlAttribute = @"enabled";
 NSString *const kHCPNativeInterfaceXmlTag = @"native-interface";
 NSString *const kHCPNativeInterfaceVersionXmlAttribute = @"version";
 
+// Keys for processing force install options
+NSString *const kHCPForceInstallXmlTag = @"force-install";
+NSString *const kHCPForceInstallEnabledXmlAttribute = @"enabled";
+
 @implementation HCPXmlTags
 
 @end

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -53,7 +53,8 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     [self subscribeToEvents];
     
     // install www folder if it is needed
-    if ([self isWWwFolderNeedsToBeInstalled]) {
+    BOOL isForceInstallAllowed = _pluginXmlConfig.isForceInstallAllowed;
+    if ([self isWWwFolderNeedsToBeInstalled] || isForceInstallAllowed) {
         [self installWwwFolder];
         return;
     }


### PR DESCRIPTION
Fixes #157 and introduces a `force-install` tag in the <chcp> tag section of the config.xml for development purposes.
If the attribute `enabled` is true, the local `www` folder will always be used disregarding the `app version`.
If the tag is not set or `enabled` is false, the default behaviour will be used.

config.xml example

```xml
…
    <chcp>
        <auto-download enabled="false" />
        <auto-install enabled="false" />
        <native-interface version="1" />
        <force-install enabled="true" />
    </chcp>
…
```