### PR TITLE
Get path to www folder

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -254,6 +254,8 @@ public class HotCodePushPlugin extends CordovaPlugin {
             jsIsUpdateAvailableForInstallation(callbackContext);
         } else if (JSAction.GET_VERSION_INFO.equals(action)) {
             jsGetVersionInfo(callbackContext);
+        } else if(JSAction.GET_WWW_PATH.equals(action)) {
+            jsGetPath(callbackContext);
         } else {
             cmdProcessed = false;
         }
@@ -463,6 +465,21 @@ public class HotCodePushPlugin extends CordovaPlugin {
 
         final PluginResult pluginResult = PluginResultHelper.createPluginResult(null, data, null);
         callback.sendPluginResult(pluginResult);
+    }
+
+    /**
+     * Get android path of current www folder
+     *
+     * @param callback callback where to send the result
+     */
+    private void jsGetPath(final CallbackContext callback) {
+        final Context context = cordova.getActivity();
+        //final Map<String, Object> data = new HashMap<String, Object>();
+        //data.put("wwwFolder", fileStructure.getWwwFolder());
+
+        //final PluginResult pluginResult = PluginResultHelper.createPluginResult(null, data, null);
+        //callback.sendPluginResult(pluginResult);
+        callback.success(fileStructure.getWwwFolder());
     }
 
     // convenience method

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -474,12 +474,12 @@ public class HotCodePushPlugin extends CordovaPlugin {
      */
     private void jsGetPath(final CallbackContext callback) {
         final Context context = cordova.getActivity();
-        //final Map<String, Object> data = new HashMap<String, Object>();
-        //data.put("wwwFolder", fileStructure.getWwwFolder());
+        final Map<String, Object> data = new HashMap<String, Object>();
+        data.put("wwwFolder", fileStructure.getWwwFolder());
 
-        //final PluginResult pluginResult = PluginResultHelper.createPluginResult(null, data, null);
-        //callback.sendPluginResult(pluginResult);
-        callback.success(fileStructure.getWwwFolder());
+        final PluginResult pluginResult = PluginResultHelper.createPluginResult(null, data, null);
+        callback.sendPluginResult(pluginResult);
+        //callback.success(fileStructure.getWwwFolder());
     }
 
     // convenience method

--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -479,7 +479,6 @@ public class HotCodePushPlugin extends CordovaPlugin {
 
         final PluginResult pluginResult = PluginResultHelper.createPluginResult(null, data, null);
         callback.sendPluginResult(pluginResult);
-        //callback.success(fileStructure.getWwwFolder());
     }
 
     // convenience method

--- a/src/android/src/com/nordnetab/chcp/main/js/JSAction.java
+++ b/src/android/src/com/nordnetab/chcp/main/js/JSAction.java
@@ -14,6 +14,7 @@ public final class JSAction {
     public static final String REQUEST_APP_UPDATE = "jsRequestAppUpdate";
     public static final String IS_UPDATE_AVAILABLE_FOR_INSTALLATION = "jsIsUpdateAvailableForInstallation";
     public static final String GET_VERSION_INFO = "jsGetVersionInfo";
+    public static final String GET_WWW_PATH = "jsGetPath";
 
     // Private API
     public static final String INIT = "jsInitPlugin";

--- a/src/ios/HCPPlugin.h
+++ b/src/ios/HCPPlugin.h
@@ -73,4 +73,10 @@
  */
 - (void)jsGetVersionInfo:(CDVInvokedUrlCommand *)command;
 
+/**
+ * Get android path of current www folder
+ *
+ * @param command command with which the method is called
+ */
+- (void)jsGetPath:(CDVInvokedUrlCommand *)command;
 @end

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -51,20 +51,20 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 -(void)pluginInitialize {
     [self doLocalInit];
     [self subscribeToEvents];
-    
+
     // install www folder if it is needed
     if ([self isWWwFolderNeedsToBeInstalled]) {
         [self installWwwFolder];
         return;
     }
-    
+
     // cleanup file system: remove older releases, except current and the previous one
     [self cleanupFileSystemFromOldReleases];
-    
+
     _isPluginReadyForWork = YES;
     [self resetIndexPageToExternalStorage];
     [self loadApplicationConfig];
-    
+
     // install update if any exists
     if (_pluginXmlConfig.isUpdatesAutoInstallationAllowed &&
         _pluginInternalPrefs.readyForInstallationReleaseVersionName.length > 0) {
@@ -81,12 +81,12 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         _pluginInternalPrefs.readyForInstallationReleaseVersionName.length == 0) {
         return;
     }
-    
+
     // load app config from update folder and check, if we are allowed to install it
     HCPFilesStructure *fs = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.readyForInstallationReleaseVersionName];
     id<HCPConfigFileStorage> configStorage = [[HCPApplicationConfigStorage alloc] initWithFileStructure:fs];
     HCPApplicationConfig *configFromNewRelease = [configStorage loadFromFolder:fs.downloadFolder];
-        
+
     if (configFromNewRelease.contentConfig.updateTime == HCPUpdateOnResume ||
         configFromNewRelease.contentConfig.updateTime == HCPUpdateNow) {
         [self _installUpdate:nil];
@@ -104,10 +104,10 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         _pluginInternalPrefs.previousReleaseVersionName = @"";
         HCPApplicationConfig *config = [HCPApplicationConfig configFromBundle:[HCPFilesStructure defaultConfigFileName]];
         _pluginInternalPrefs.currentReleaseVersionName = config.contentConfig.releaseVersion;
-        
+
         [_pluginInternalPrefs saveToUserDefaults];
     }
-    
+
     [HCPAssetsFolderHelper installWwwFolderToExternalStorageFolder:_filesStructure.wwwFolder];
 }
 
@@ -129,7 +129,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     BOOL isApplicationUpdated = ![[NSBundle applicationBuildVersion] isEqualToString:_pluginInternalPrefs.appBuildVersion];
     BOOL isWWwFolderExists = [fileManager fileExistsAtPath:_filesStructure.wwwFolder.path];
     BOOL isWWwFolderInstalled = _pluginInternalPrefs.isWwwFolderInstalled;
-    
+
     return isApplicationUpdated || !isWWwFolderExists || !isWWwFolderInstalled;
 }
 
@@ -138,19 +138,19 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)doLocalInit {
     _defaultCallbackStoredResults = [[NSMutableArray alloc] init];
-    
+
     // init plugin config from xml
     _pluginXmlConfig = [HCPXmlConfig loadFromCordovaConfigXml];
-    
+
     // load plugin internal preferences
     _pluginInternalPrefs = [HCPPluginInternalPreferences loadFromUserDefaults];
     if (_pluginInternalPrefs == nil || _pluginInternalPrefs.currentReleaseVersionName.length == 0) {
         _pluginInternalPrefs = [HCPPluginInternalPreferences defaultConfig];
         [_pluginInternalPrefs saveToUserDefaults];
     }
-    
+
     NSLog(@"Currently running release version %@", _pluginInternalPrefs.currentReleaseVersionName);
-    
+
     // init file structure for www files
     _filesStructure = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.currentReleaseVersionName];
 }
@@ -166,20 +166,20 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (!_isPluginReadyForWork) {
         return NO;
     }
-    
+
     if (!options && self.defaultFetchUpdateOptions) {
         options = self.defaultFetchUpdateOptions;
     }
-    
+
     HCPUpdateRequest *request = [[HCPUpdateRequest alloc] init];
     request.configURL = options.configFileURL ? options.configFileURL : _pluginXmlConfig.configUrl;
     request.requestHeaders = options.requestHeaders;
     request.currentWebVersion = _pluginInternalPrefs.currentReleaseVersionName;
     request.currentNativeVersion = _pluginXmlConfig.nativeInterfaceVersion;
-    
+
     NSError *error = nil;
     [[HCPUpdateLoader sharedInstance] executeDownloadRequest:request error:&error];
-    
+
     if (error) {
         if (callbackId) {
             CDVPluginResult *errorResult = [CDVPluginResult pluginResultWithActionName:kHCPUpdateDownloadErrorEvent
@@ -187,14 +187,14 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                                                                                  error:error];
             [self.commandDelegate sendPluginResult:errorResult callbackId:callbackId];
         }
-        
+
         return NO;
     }
-    
+
     if (callbackId) {
         _downloadCallback = callbackId;
     }
-    
+
     return YES;
 }
 
@@ -209,10 +209,10 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (!_isPluginReadyForWork) {
         return NO;
     }
-    
+
     NSString *newVersion = _pluginInternalPrefs.readyForInstallationReleaseVersionName;
     NSString *currentVersion = _pluginInternalPrefs.currentReleaseVersionName;
-    
+
     NSError *error = nil;
     [[HCPUpdateInstaller sharedInstance] installVersion:newVersion currentVersion:currentVersion error:&error];
     if (error) {
@@ -230,10 +230,10 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                 [self.commandDelegate sendPluginResult:errorResult callbackId:callbackID];
             }
         }
-        
+
         return NO;
     }
-    
+
     if (callbackID) {
         _installationCallback = callbackID;
     }
@@ -265,17 +265,17 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)resetIndexPageToExternalStorage {
     NSString *indexPageStripped = [self indexPageFromConfigXml];
-    
+
     NSRange r = [indexPageStripped rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"?#"] options:0];
     if (r.location != NSNotFound) {
         indexPageStripped = [indexPageStripped substringWithRange:NSMakeRange(0, r.location)];
     }
-    
+
     NSURL *indexPageExternalURL = [self appendWwwFolderPathToPath:indexPageStripped];
     if (![[NSFileManager defaultManager] fileExistsAtPath:indexPageExternalURL.path]) {
         return;
     }
-    
+
     // rewrite starting page www folder path: should load from external storage
     if ([self.viewController isKindOfClass:[CDVViewController class]]) {
         ((CDVViewController *)self.viewController).wwwFolderName = _filesStructure.wwwFolder.absoluteString;
@@ -295,7 +295,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if ([pagePath hasPrefix:_filesStructure.wwwFolder.absoluteString]) {
         return [NSURL URLWithString:pagePath];
     }
-    
+
     return [_filesStructure.wwwFolder URLByAppendingPathComponent:pagePath];
 }
 
@@ -308,27 +308,27 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (_indexPage) {
         return _indexPage;
     }
-    
+
     CDVConfigParser* delegate = [[CDVConfigParser alloc] init];
-    
+
     // read from config.xml in the app bundle
     NSURL* url = [NSURL fileURLWithPath:[NSBundle pathToCordovaConfigXml]];
-    
+
     NSXMLParser *configParser = [[NSXMLParser alloc] initWithContentsOfURL:url];
     [configParser setDelegate:((id <NSXMLParserDelegate>)delegate)];
     [configParser parse];
-    
+
     if (delegate.startPage) {
         _indexPage = delegate.startPage;
     } else {
         _indexPage = DEFAULT_STARTING_PAGE;
     }
-    
+
     return _indexPage;
 }
 
 /**
- *  Notify JavaScript module about occured event. 
+ *  Notify JavaScript module about occured event.
  *  For that we will use callback, received on plugin initialization stage.
  *
  *  @param result message to send to web side
@@ -339,10 +339,10 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [_defaultCallbackStoredResults addObject:result];
         return NO;
     }
-    
+
     [result setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:result callbackId:_defaultCallbackID];
-    
+
     return YES;
 }
 
@@ -350,7 +350,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (!_defaultCallbackID || _defaultCallbackStoredResults.count == 0) {
         return;
     }
-    
+
     for (CDVPluginResult *callResult in _defaultCallbackStoredResults) {
         [callResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:callResult callbackId:_defaultCallbackID];
@@ -383,7 +383,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)subscribeToPluginInternalEvents {
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    
+
     // bundle installation events
     [notificationCenter addObserver:self
                            selector:@selector(onBeforeAssetsInstalledOnExternalStorageEvent:)
@@ -397,7 +397,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                            selector:@selector(onAssetsInstallationErrorEvent:)
                                name:kHCPBundleAssetsInstallationErrorEvent
                              object:nil];
-    
+
     // update download events
     [notificationCenter addObserver:self
                            selector:@selector(onUpdateDownloadErrorEvent:)
@@ -411,7 +411,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                            selector:@selector(onUpdateIsReadyForInstallation:)
                                name:kHCPUpdateIsReadyForInstallationEvent
                              object:nil];
-    
+
     // update installation events
     [notificationCenter addObserver:self
                            selector:@selector(onUpdateInstallationErrorEvent:)
@@ -432,7 +432,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 }
 
 /**
- *  Remove subscription. 
+ *  Remove subscription.
  *  Should be called only when the application is terminated.
  */
 - (void)unsubscribeFromEvents {
@@ -461,16 +461,16 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     _pluginInternalPrefs.appBuildVersion = [NSBundle applicationBuildVersion];
     _pluginInternalPrefs.wwwFolderInstalled = YES;
     [_pluginInternalPrefs saveToUserDefaults];
-    
+
     // allow work
     _isPluginReadyForWork = YES;
-    
+
     // send notification to web
     [self invokeDefaultCallbackWithMessage:[CDVPluginResult pluginResultForNotification:notification]];
-    
+
     // fetch update
     [self loadApplicationConfig];
-    
+
     if (_pluginXmlConfig.isUpdatesAutoDownloadAllowed &&
         ![HCPUpdateLoader sharedInstance].isDownloadInProgress &&
         ![HCPUpdateInstaller sharedInstance].isInstallationInProgress) {
@@ -485,7 +485,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)onAssetsInstallationErrorEvent:(NSNotification *)notification {
     _isPluginReadyForWork = NO;
-    
+
     // send notification to web
     [self invokeDefaultCallbackWithMessage:[CDVPluginResult pluginResultForNotification:notification]];
 }
@@ -501,17 +501,17 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 - (void)onUpdateDownloadErrorEvent:(NSNotification *)notification {
     NSError *error = notification.userInfo[kHCPEventUserInfoErrorKey];
     NSLog(@"Error during update: %@", [error underlyingErrorLocalizedDesription]);
-    
+
     // send notification to the associated callback
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
     if (_downloadCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_downloadCallback];
         _downloadCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
-    
+
     // probably never happens, but just for safety
     [self rollbackIfCorrupted:error];
 }
@@ -523,14 +523,14 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)onNothingToUpdateEvent:(NSNotification *)notification {
     NSLog(@"Nothing to update");
-    
+
     // send notification to the associated callback
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
     if (_downloadCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_downloadCallback];
         _downloadCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
 }
@@ -543,23 +543,23 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 - (void)onUpdateIsReadyForInstallation:(NSNotification *)notification {
     // new application config from server
     HCPApplicationConfig *newConfig = notification.userInfo[kHCPEventUserInfoApplicationConfigKey];
-    
+
     NSLog(@"Update is ready for installation: %@", newConfig.contentConfig.releaseVersion);
-    
+
     // store, that we are ready for installation
     _pluginInternalPrefs.readyForInstallationReleaseVersionName = newConfig.contentConfig.releaseVersion;
     [_pluginInternalPrefs saveToUserDefaults];
-    
+
     // send notification to the associated callback
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
     if (_downloadCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_downloadCallback];
         _downloadCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
-    
+
     // if it is allowed - launch the installation
     if (_pluginXmlConfig.isUpdatesAutoInstallationAllowed &&
         newConfig.contentConfig.updateTime == HCPUpdateNow &&
@@ -578,13 +578,13 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)onNothingToInstallEvent:(NSNotification *)notification {
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
-    
+
     // send notification to the caller from the JavaScript side if there was any
     if (_installationCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_installationCallback];
         _installationCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
 }
@@ -596,7 +596,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)onBeforeInstallEvent:(NSNotification *)notification {
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
 }
@@ -609,18 +609,18 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 - (void)onUpdateInstallationErrorEvent:(NSNotification *)notification {
     _pluginInternalPrefs.readyForInstallationReleaseVersionName = @"";
     [_pluginInternalPrefs saveToUserDefaults];
-    
+
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
-    
+
     // send notification to the caller from the JavaScript side if there was any
     if (_installationCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_installationCallback];
         _installationCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
-    
+
     // probably never happens, but just for safety
     NSError *error = notification.userInfo[kHCPEventUserInfoErrorKey];
     [self rollbackIfCorrupted:error];
@@ -633,28 +633,28 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
  */
 - (void)onUpdateInstalledEvent:(NSNotification *)notification {
     _appConfig = notification.userInfo[kHCPEventUserInfoApplicationConfigKey];
-    
+
     _pluginInternalPrefs.readyForInstallationReleaseVersionName = @"";
     _pluginInternalPrefs.previousReleaseVersionName = _pluginInternalPrefs.currentReleaseVersionName;
     _pluginInternalPrefs.currentReleaseVersionName = _appConfig.contentConfig.releaseVersion;
     [_pluginInternalPrefs saveToUserDefaults];
-    
+
     _filesStructure = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.currentReleaseVersionName];
-    
+
     CDVPluginResult *pluginResult = [CDVPluginResult pluginResultForNotification:notification];
-    
+
     // send notification to the caller from the JavaScript side of there was any
     if (_installationCallback) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_installationCallback];
         _installationCallback = nil;
     }
-    
+
     // send notification to the default callback
     [self invokeDefaultCallbackWithMessage:pluginResult];
-    
+
     // reload application to the index page
     [self loadURL:[self indexPageFromConfigXml]];
-    
+
     [self cleanupFileSystemFromOldReleases];
 }
 
@@ -668,13 +668,13 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     _pluginInternalPrefs.currentReleaseVersionName = _pluginInternalPrefs.previousReleaseVersionName;
     _pluginInternalPrefs.previousReleaseVersionName = @"";
     [_pluginInternalPrefs saveToUserDefaults];
-    
+
     _filesStructure = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.currentReleaseVersionName];
-    
+
     if (_appConfig) {
         [self loadApplicationConfig];
     }
-    
+
     [self loadURL:[self indexPageFromConfigXml]];
 }
 
@@ -687,7 +687,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (error.code != kHCPLocalVersionOfApplicationConfigNotFoundErrorCode && error.code != kHCPLocalVersionOfManifestNotFoundErrorCode) {
         return;
     }
-    
+
     if (_pluginInternalPrefs.previousReleaseVersionName.length > 0) {
         NSLog(@"WWW folder is corrupted, rolling back to previous version.");
         [self rollbackToPreviousRelease];
@@ -703,7 +703,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     if (!_pluginInternalPrefs.currentReleaseVersionName.length) {
         return;
     }
-    
+
     [HCPCleanupHelper removeUnusedReleasesExcept:@[_pluginInternalPrefs.currentReleaseVersionName,
                                                    _pluginInternalPrefs.previousReleaseVersionName,
                                                    _pluginInternalPrefs.readyForInstallationReleaseVersionName]];
@@ -714,7 +714,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 - (void)jsInitPlugin:(CDVInvokedUrlCommand *)command {
     _defaultCallbackID = command.callbackId;
     [self dispatchDefaultCallbackStoredResults];
-    
+
     if (_pluginXmlConfig.isUpdatesAutoDownloadAllowed &&
         ![HCPUpdateLoader sharedInstance].isDownloadInProgress &&
         ![HCPUpdateInstaller sharedInstance].isInstallationInProgress) {
@@ -727,11 +727,11 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [self sendPluginNotReadyToWorkMessageForEvent:nil callbackID:command.callbackId];
         return;
     }
-    
+
     NSDictionary *options = command.arguments[0];
     [_pluginXmlConfig mergeOptionsFromJS:options];
     // TODO: store them somewhere?
-    
+
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -743,7 +743,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
 
     NSDictionary *optionsFromJS = command.arguments.count ? command.arguments[0] : nil;
     HCPFetchUpdateOptions *fetchOptions = [[HCPFetchUpdateOptions alloc] initWithDictionary:optionsFromJS];
-    
+
     [self _fetchUpdate:command.callbackId withOptions:fetchOptions];
 }
 
@@ -752,7 +752,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [self sendPluginNotReadyToWorkMessageForEvent:kHCPUpdateInstallationErrorEvent callbackID:command.callbackId];
         return;
     }
-    
+
     [self _installUpdate:command.callbackId];
 }
 
@@ -761,12 +761,12 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [self sendPluginNotReadyToWorkMessageForEvent:nil callbackID:command.callbackId];
         return;
     }
-    
+
     NSString* message = command.arguments[0];
     if (message.length == 0) {
         return;
     }
-    
+
     _appUpdateRequestDialog = [[HCPAppUpdateRequestAlertDialog alloc] initWithMessage:message storeUrl:_appConfig.storeUrl onSuccessBlock:^{
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
         _appUpdateRequestDialog = nil;
@@ -774,7 +774,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR] callbackId:command.callbackId];
         _appUpdateRequestDialog = nil;
     }];
-    
+
     [_appUpdateRequestDialog show];
 }
 
@@ -787,7 +787,7 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
     } else {
         error = [NSError errorWithCode:kHCPNothingToInstallErrorCode description:@"Nothing to install"];
     }
-    
+
     CDVPluginResult *result = [CDVPluginResult pluginResultWithActionName:nil data:data error:error];
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }
@@ -798,6 +798,13 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
                            @"previousWebVersion": _pluginInternalPrefs.previousReleaseVersionName,
                            @"appVersion": [NSBundle applicationVersionName],
                            @"buildVersion": [NSBundle applicationBuildVersion]};
+
+    CDVPluginResult *result = [CDVPluginResult pluginResultWithActionName:nil data:data error:nil];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void)jsGetPath:(CDVInvokedUrlCommand *)command {
+    NSDictionary *data = @{@"wwwFolder": _filesStructure.wwwFolder.absoluteString};
 
     CDVPluginResult *result = [CDVPluginResult pluginResultWithActionName:nil data:data error:nil];
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];

--- a/www/chcp.js
+++ b/www/chcp.js
@@ -284,8 +284,6 @@ var chcp = {
    */
   getPath: function(callback) {
     callNativeMethod(pluginNativeMethod.GET_PATH, null, callback);
-    //TODO: Fit in Plug-In logic.
-    //exec(callback, null, PLUGIN_NAME, pluginNativeMethod.GET_PATH, []);
   }
 };
 

--- a/www/chcp.js
+++ b/www/chcp.js
@@ -14,7 +14,8 @@ var exec = require('cordova/exec'),
     CONFIGURE: 'jsConfigure',
     REQUEST_APP_UPDATE: 'jsRequestAppUpdate',
     IS_UPDATE_AVAILABLE_FOR_INSTALLATION: 'jsIsUpdateAvailableForInstallation',
-    GET_INFO: 'jsGetVersionInfo'
+    GET_INFO: 'jsGetVersionInfo',
+    GET_PATH: 'jsGetPath'
   };
 
 // Called when Cordova is ready for work.
@@ -274,6 +275,17 @@ var chcp = {
    */
   getVersionInfo: function(callback) {
     callNativeMethod(pluginNativeMethod.GET_INFO, null, callback);
+  },
+
+  /**
+   * Get www path for current version.
+   *
+   * @param {Callback(error, data)} callback - called, when information is retrieved from the native side.
+   */
+  getPath: function(callback) {
+    //callNativeMethod(pluginNativeMethod.GET_PATH, null, callback);
+    //TODO: Fit in Plug-In logic.
+    exec(callback, null, PLUGIN_NAME, pluginNativeMethod.GET_PATH, []);
   }
 };
 

--- a/www/chcp.js
+++ b/www/chcp.js
@@ -283,9 +283,9 @@ var chcp = {
    * @param {Callback(error, data)} callback - called, when information is retrieved from the native side.
    */
   getPath: function(callback) {
-    //callNativeMethod(pluginNativeMethod.GET_PATH, null, callback);
+    callNativeMethod(pluginNativeMethod.GET_PATH, null, callback);
     //TODO: Fit in Plug-In logic.
-    exec(callback, null, PLUGIN_NAME, pluginNativeMethod.GET_PATH, []);
+    //exec(callback, null, PLUGIN_NAME, pluginNativeMethod.GET_PATH, []);
   }
 };
 


### PR DESCRIPTION
I added a function that gives you the path to the www folder where the CHCP'ed files are located.

This function can be useful if you have another native plugin that needs the paths to some files. 
In my context, I need this path for doing some crypto stuff on files that are CHCP'ed also.

Note: I do not own a Mac, so I was not able to test the iOS code, but I hope it does the job.