### PR TITLE
Mention that apps connect to your cordova-hcp server when looking for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ When you publish your application on the store - you pack in it all your web con
 1. Publish new version of the app on the store. But it takes time, especially with the App Store.
 2. Sacrifice the offline feature and load all the pages online. But as soon as Internet connection goes down - application won't work.
 
-This plugin is intended to fix all that. When user starts the app for the first time - it copies all the web files onto the external storage. From this moment all pages are loaded from the external folder and not from the packed bundle. On every launch plugin connects to your server (with optional authentication, see fetchUpdate() below) and checks if the new version of web project is available for download. If so - it loads it on the device and installs on the next launch.
+This plugin is intended to fix all that. When user starts the app for the first time - it copies all the web files onto the external storage. From this moment all pages are loaded from the external folder and not from the packed bundle. On every launch plugin connects to your cordova-hcp server (with optional authentication, see fetchUpdate() below) and checks if the new version of web project is available for download. If so - it loads it on the device and installs on the next launch.
 
 As a result, your application receives updates of the web content as soon as possible, and still can work in offline mode. Also, plugin allows you to specify dependency between the web release and the native version to make sure, that new release will work on the older versions of the application.
 


### PR DESCRIPTION
I spun my wheels for hours trying to figure out how to use this project to broadcast updates. I had assumed that we put our application on a static server and then modify the manifest, but then I couldn't find documentation on how exactly you typically go about that. Only after finally giving in and trying the quick start guide did I realize that the `cordova-hcp server` command spins up that server that broadcasts updated manifests and files. I had figured that quick start was just for some local development use case which I did not yet understand why it was needed.